### PR TITLE
adds conda recipe

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,2 @@
+%PYTHON% setup.py install
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,5 @@
+mkdir src
+cd src
+cp -r $RECIPE_DIR/../* .
+
+$PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: fisx
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '')[1:] }}
+
+source:
+  git_url: ../
+  git_tag: master # change to branch or tag name, as needed
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - python
+    - cython
+    - numpy
+  run:
+    - python
+    - numpy
+    - pymca
+
+test:
+  requires:
+    - pymca
+  imports:
+    - fisx
+
+about:
+  license: MIT
+  home: http://pymca.sourceforge.net
+  summary: Resources for synchrotron data analysis

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,7 +8,6 @@ source:
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  detect_binary_files_with_prefix: true
 
 requirements:
   build:

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+
+if sys.version.startswith('2.6') or sys.version.startswith('3.1'):
+    import unittest2 as unittest
+else:
+    import unittest
+
+suite = unittest.TestLoader().discover('fisx')
+unittest.TextTestRunner(verbosity=1).run(suite)


### PR DESCRIPTION
Adds a simple conda recipe. Building the recipe also runs a test procedure:

1) creates a test environment
2) installs fisx and its requirements
3) attempts to import fisx
4) runs the test suite

The test suite reports some errors that I don't believe are specific to the conda package:

AssertionError: unassigned fisx.DataDir.DATA_DIR
AssertionError: unassigned fisx.DataDir.DOC_DIR

As far as I can tell, there is nothing in this package to set DATA_DIR and DOC_DIR. DataDir does contain FISX_DATA_DIR and FISX_DOC_DIR variables.
