### PR TITLE
reproducible-builds fix - FISX_DOC_DIR change from Absolute path to Relative path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,8 @@ class smart_build_py(build_py):
             if lineToBeWritten.startswith("FISX_DATA_DIR"):
                 lineToBeWritten = "FISX_DATA_DIR = r'%s'\n" % FISX_DATA_DIR
             if line.startswith("FISX_DOC_DIR"):
+                if os.getcwd() in FISX_DOC_DIR:
+                   FISX_DOC_DIR = FISX_DOC_DIR.replace(os.getcwd()+"/","")
                 lineToBeWritten = "FISX_DOC_DIR = r'%s'\n" % FISX_DOC_DIR
             fid.write(lineToBeWritten)
         fid.close()


### PR DESCRIPTION
Make the build reproducible:
* Converted the absolute path of FISX_DOC_DIR variable in setup.py to relative path to make the build reproducible
* Tested with Debian

Based on the reproducible-builds effort https://reproducible-builds.org/

Issue: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/python-fisx.html