### PR TITLE
Make tests not depend on PyMca

### DIFF
--- a/python/fisx/tests/testSimpleSpecfile.py
+++ b/python/fisx/tests/testSimpleSpecfile.py
@@ -208,8 +208,9 @@ def getSuite(auto=True):
             "testSimpleSpecfileReadingWithCRLF"))
         testSuite.addTest(\
             testSimpleSpecfile("testSimpleSpecfileReadingCompatibleWithUserLocale"))
-        testSuite.addTest(\
-            testSimpleSpecfile("testSimpleSpecfileVersusPyMca"))
+        if PYMCA:
+            testSuite.addTest(\
+                testSimpleSpecfile("testSimpleSpecfileVersusPyMca"))
     return testSuite
 
 def test(auto=False):


### PR DESCRIPTION
This makes `fisx.tests.testAll.main()` not depend on PyMca.

`ValueError: no such test method in <class 'testSimpleSpecfile.testSimpleSpecfile'>: testSimpleSpecfileVersusPyMca`