### PR TITLE
Add missing include.

### DIFF
--- a/src/fisx_element.cpp
+++ b/src/fisx_element.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <math.h>
 #include <stdexcept>
+#include <algorithm>
 
 namespace fisx
 {


### PR DESCRIPTION
It was giving compilation issues under windows with python < 3.10 but not above that version.